### PR TITLE
New testing strategy for testing hapi server

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,6 @@ Glue.compose(Manifest, { relativeTo: process.cwd() + '/lib' }, (err, server) => 
     });
   }
   else {
-    module.exports = server;
+    module.exports.server = server;
   }
 });

--- a/index.js
+++ b/index.js
@@ -4,15 +4,12 @@ const Glue = require('glue');
 const Manifest = require('./lib');
 
 Glue.compose(Manifest, { relativeTo: process.cwd() + '/lib' }, (err, server) => {
-  if (!module.parent) {
-    server.start((err) => {
-      if (err) {
-        return console.log(err);
-      }
-      console.log(`Server running at ${server.info.uri}`);
-    });
-  }
-  else {
-    module.exports.server = server;
-  }
+
+  server.start((err) => {
+
+    if (err) {
+      return console.log(err);
+    }
+    console.log(`Server running at ${server.info.uri}`);
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -3,14 +3,37 @@
 const Code = require('code');
 const Lab = require('lab');
 
-const server = require('../');
+const Glue = require('glue');
+const manifest = require('../lib');
 
 const lab = exports.lab = Lab.script();
 const it = lab.test;
 const describe = lab.experiment;
 const expect = Code.expect;
+const beforeEach = lab.beforeEach;
+const afterEach = lab.afterEach;
 
 const levelPath = './.temp';
+
+let server = null
+
+beforeEach((done) => {
+
+  Glue.compose(manifest, { relativeTo: process.cwd() + '/lib' }, (err, testServer) => {
+
+    server = testServer
+    done()
+  })
+})
+
+afterEach((done) => {
+
+  server.stop(() => {
+
+    server = null
+    done()
+  })
+})
 
 describe('Users', () => {
   it('creates a user', { parallel: false }, (done) => {
@@ -35,7 +58,7 @@ describe('Users', () => {
           expect(res.statusCode).to.equal(200);
           expect(result.firstname).to.equal(payload.firstname);
           expect(result.lastname).to.equal(payload.lastname);
-          server.stop(done);
+          done()
         });
   });
 });


### PR DESCRIPTION
In response to your question before @annievalla, this is the approach I would use:

- index.js - this is the entry file for launching your server. (normally I would have this in lib/index)
- test/index.js - entry file for testing your server.

beforeEach, afterEach should be used, as you should be testing a fresh server in each test. No shared resources.

Assignment 5 of hapi university expands on this idea further in this example: https://github.com/hapijs/university/tree/assignment5